### PR TITLE
Login Page + Routing

### DIFF
--- a/APIFuncs/MariaDBapi.py
+++ b/APIFuncs/MariaDBapi.py
@@ -2,7 +2,7 @@ import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from datetime import datetime
 
-engine = sqlalchemy.create_engine("mariadb+mariadbconnector://root:X%i7us7tCMg9bmKQp&9rD&@127.0.0.1/PTCBozeman")
+engine = sqlalchemy.create_engine("mariadb+mariadbconnector://root:lovering@127.0.0.1/ptctest")
 Base = declarative_base()
 
 class Attendee(Base):
@@ -26,7 +26,7 @@ class Administrator(Base):
         __tablename__ = 'Administrators'
         ID = sqlalchemy.Column(sqlalchemy.String(length=24), primary_key =True)
         UserName = sqlalchemy.Column(sqlalchemy.String(length=32))
-        Password = sqlalchemy.Column(sqlalchemy.String(length=32))
+        Password = sqlalchemy.Column(sqlalchemy.String(length=128))
 
 
 class AttendanceEvent(Base):

--- a/APIFuncs/MariaDBapi.py
+++ b/APIFuncs/MariaDBapi.py
@@ -2,7 +2,7 @@ import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from datetime import datetime
 
-engine = sqlalchemy.create_engine("mariadb+mariadbconnector://root:lovering@127.0.0.1/ptctest")
+engine = sqlalchemy.create_engine("mariadb+mariadbconnector://root:X%i7us7tCMg9bmKQp&9rD&@127.0.0.1/PTCBozeman")
 Base = declarative_base()
 
 class Attendee(Base):

--- a/APIFuncs/auth.py
+++ b/APIFuncs/auth.py
@@ -1,0 +1,39 @@
+import hashlib
+import os
+
+
+# This function takes in a string, then salts, encrypts and appends
+# the salt to the string for decryption.
+def encrypt(stringToBeEncrypted):
+    # Generate a 16-byte salt
+    salt = os.urandom(16)
+    # Concatenate with string to be encrypted
+    salted_input = salt + stringToBeEncrypted.encode('utf-8')
+    #Hash the salted input
+    hashedString = hashlib.sha256(salted_input).digest()
+    # Add salt to front for reference in decryption
+    salt_and_hash = salt + hashedString
+    #return as hex string for entry in DB.
+    return salt_and_hash.hex()
+
+# This function pulls 
+def decrypt(stringToBeDecrypted):
+    #Convert the hex string into bytes
+    salt_and_hash = bytes.fromhex(stringToBeDecrypted)
+    print(salt_and_hash)
+    # Extract the salt (first 16 bytes)
+    salt = salt_and_hash[:16]
+    print(salt)
+    hashedString = salt_and_hash[16:]
+    print(hashedString)
+
+#def createToken():
+#def attemptLogin(username, password):
+
+
+if __name__ == "__main__":
+    testVal = 'Test'
+    print(testVal)
+    test = encrypt(testVal)
+    print(test)
+    decrypt(test)

--- a/APIFuncs/auth.py
+++ b/APIFuncs/auth.py
@@ -1,6 +1,6 @@
 import hashlib
 import os
-
+from APIFuncs import MariaDBapi as api
 
 # This function takes in a string, then salts, encrypts and appends
 # the salt to the string for decryption.
@@ -16,7 +16,7 @@ def encrypt(stringToBeEncrypted):
     #return as hex string for entry in DB.
     return salt_and_hash.hex()
 
-# This function pulls 
+# This function pulls
 def decrypt(stringToBeDecrypted):
     #Convert the hex string into bytes
     salt_and_hash = bytes.fromhex(stringToBeDecrypted)
@@ -28,7 +28,10 @@ def decrypt(stringToBeDecrypted):
     print(hashedString)
 
 #def createToken():
-#def attemptLogin(username, password):
+
+#This function attempts to check the login of a user, and returns true if it is valid
+def attemptLogin(username, password):
+
 
 
 if __name__ == "__main__":

--- a/APIFuncs/utils.py
+++ b/APIFuncs/utils.py
@@ -10,6 +10,7 @@ import collections
 import json
 
 import sqlalchemy.cyextension
+from APIFuncs import auth
 from APIFuncs import MariaDBapi as api
 from APIFuncs import JSONHandler as jsonhandler
 import sqlalchemy
@@ -255,7 +256,7 @@ def createAdministrator(AdministratorJSON):
     NewAdministrator = api.Administrator(
         ID=AdministratorJSON['ID'],
         UserName=AdministratorJSON['username'],
-        Password=AdministratorJSON['password']  #TODO: Create a function that encrypts + salts this, outside of utils.py
+        Password=auth.encrypt(AdministratorJSON['password'])
     )
     #Add to DB
     NASession.add(NewAdministrator)
@@ -275,13 +276,13 @@ def editAdministrator(editAdministratorJSON):
         if editAdministratorJSON['UserName']:
             admin.UserName = editAdministratorJSON['UserName']
         if editAdministratorJSON['Password']:
-            admin.Password = editAdministratorJSON['Password']
+            admin.Password = auth.encrypt(editAdministratorJSON['Password'])
     else:
         #This shouldn't be happening, as the attendee has to exist in the database to be displayed, but create a new attendee if that is the case
         newAdmin = api.Administrator(
             ID=editAdministratorJSON['ID'],
             UserName=editAdministratorJSON['UserName'],
-            Password=editAdministratorJSON['Password']
+            Password=auth.encrypt(editAdministratorJSON['Password'])
         )
         Session.add(newAdmin)
     Session.commit()
@@ -314,6 +315,17 @@ def getAttendee(AttendeeID):
     query = Session.query(api.Attendee).filter_by(ID=AttendeeID).first()
     Session.close()
     return query
+
+def getIDFromAdministrator(username):
+    # Create Sqlalchemy Session
+    api.Base.metadata.create_all(api.engine)
+    Session = sqlalchemy.orm.sessionmaker()
+    Session.configure(bind=api.engine)
+    Session = Session()
+    #Query for attendee from administrator
+    query = Session.query(api.Administrator).filter_by(UserName=username).first()
+    Session.close()
+    return query.ID
 
 
 #Returns all attendees and data from the database.

--- a/APIFuncs/utils.py
+++ b/APIFuncs/utils.py
@@ -406,7 +406,7 @@ def createEventFromWeb(eventData):
         Timestamp=date,
         Absent=eventData.get('absence'),
         TIL_Violation=eventData.get('tail'),
-        AdminInitials="N/A",  #TODO: Unimplemented, will be added with log.
+        AdminInitials=eventData.get('adminInitials'),
         Comment=eventData.get('comment'))
 
     #Add NewAttendanceEvent to the database.
@@ -444,7 +444,7 @@ def editEvent(eventData):
         eventToEdit.Timestamp = date
         eventToEdit.Absent = eventData.get('absence')
         eventToEdit.TIL_Violation = eventData.get('tail')
-        eventToEdit.AdminInitials = "N/A"
+        eventToEdit.AdminInitials = eventData.get('adminInitials')
         eventToEdit.Comment = eventData.get('comment')
     else:
         editedEvent = api.AttendanceEvent(
@@ -454,7 +454,7 @@ def editEvent(eventData):
             Timestamp=date,
             Absent=eventData.get('absence'),
             TIL_Violation=eventData.get('tail'),
-            AdminInitials="N/A",
+            AdminInitials=eventData.get('adminInitials'),
             Comment=eventData.get('comment')
         )
         Session.add(editedEvent)

--- a/flaskServer/app.py
+++ b/flaskServer/app.py
@@ -4,10 +4,13 @@ import uuid
 
 from flask import Flask, Blueprint, render_template, send_from_directory, request, jsonify, make_response, send_file
 from flask_cors import CORS
+from flask_jwt_extended import create_access_token, JWTManager
+
 from reports import generateReport, reportScheduler
 from APIFuncs import utils
 from APIFuncs import MariaDBapi
 from APIFuncs import badgeGenerator
+from APIFuncs import auth
 import sys
 import os
 import time
@@ -17,9 +20,19 @@ import schedule
 #Need threading for schedules
 from threading import Thread
 
+#Initialize Flask App
 app = Flask(__name__)
+
+#Cross Origin Configuratoin
 #CORS(app,resources={r"*": {"origins":"http://localhost:5173"""}})
 CORS(app)
+
+#JWT Configuration (For session tokens)
+app.config['JWT_SECRET_KEY'] = 'faf4f00ab5cdc4b33e197d879118da6730cb7d9bd71cfdff253f9772e346465313daf5dc6f744ae5de5d9dc77142808cad673cfeab879c2b7d7e7ccaff0fc43a'
+app.config['JWT_ACCESS_TOKEN_EXPIRES'] = datetime.timedelta(hours=12)  #12 hours before relogin.
+jwt = JWTManager(app)
+
+#Add Pathing for external folders
 sys.path.append(os.path.join(sys.path[0], '/xlsx'))
 sys.path.append(os.path.join(sys.path[0], '/profileImage'))
 image_folder = 'flaskServer/profileImage'
@@ -27,11 +40,15 @@ image_folder = 'flaskServer/profileImage'
 
 #--Schedule funciton. Needs to stay in the main flask app ----------------------------------------------
 def ScheduleManager():
-    while 1: 
+    while 1:
         schedule.run_pending()
         time.sleep(5)
 
+
 #----------Web Routes ------------------------------------------------------------------------------------
+
+
+#----------Report Routes ---------------------------------------------------------------------------------
 @app.route('/api/generateReport', methods=['GET', 'POST'])
 def generate_report():
     data = request.json
@@ -43,7 +60,7 @@ def generate_report():
     #Checking if file exists for a minute before throwing an error.
     start_time = time.time()
     while time.time() - start_time < 60:
-        if os.path.isfile('/home/55ATAT/55ATAT/flaskServer/xlsx/'+fileName):
+        if os.path.isfile('/home/55ATAT/55ATAT/flaskServer/xlsx/' + fileName):
             print('found file')
             return make_response(jsonify(fileName), 200)
         time.sleep(1)
@@ -53,9 +70,11 @@ def generate_report():
 @app.route('/api/download/<path:filename>', methods=['GET', 'POST'])
 def download_file(filename):
     print("filename received: " + filename)
-    return send_from_directory(directory='xlsx', path = filename, as_attachment=True)
+    return send_from_directory(directory='xlsx', path=filename, as_attachment=True)
 
-@app.route('/api/attendeeInitials',methods=['GET'])
+
+#--------------- Getter Routes -----------------------------------------------------
+@app.route('/api/attendeeInitials', methods=['GET'])
 def getAttendeeInitials():
     return make_response(utils.getAllUserInitials(), 200)
 
@@ -64,17 +83,20 @@ def getAttendeeInitials():
 def getRoles():
     return make_response(jsonify(utils.getRoles()), 200)
 
-@app.route('/api/getAllAttendees' , methods=['GET'])
+
+@app.route('/api/getAllAttendees', methods=['GET'])
 def getAllAttendees():
-   return make_response(jsonify(utils.getAllAttendees()), 200)
+    return make_response(jsonify(utils.getAllAttendees()), 200)
+
 
 #This endpoint returns the 50 most recent attendance events for usage in the webpage table. This can be expanded based on testing.
 @app.route('/api/getRecentEvents', methods=['GET'])
 def getRecentEvents():
     return make_response(jsonify(utils.getEvents(50)), 200)
 
+
 #This endpoint takes a userID, and creates an attendance event with it
-@app.route('/api/scanEvent',methods=['POST'])
+@app.route('/api/scanEvent', methods=['POST'])
 def scanEvent():
     data = request.json
     return make_response(jsonify(utils.NewAttendanceEvent(data.get('id'))), 200)
@@ -120,6 +142,7 @@ def createAccount():
             f.write(image.read())
     return make_response(jsonify(UserID), 200)
 
+
 @app.route('/api/generateBadge', methods=['POST'])
 def generateQR():
     # Get Data for UserID
@@ -127,6 +150,7 @@ def generateQR():
     # Call generate_badge, which will create a badge and URL for it.
     badgeURL = badgeGenerator.generate_badge(data.get('userID'))
     return make_response(badgeURL, 200)
+
 
 @app.route('/api/createAdmin', methods=['POST'])
 def createAdministrator():
@@ -141,6 +165,7 @@ def createAdministrator():
     utils.createAdministrator(newAdministrator)
     return make_response(jsonify({"message": "Success"}), 200)
 
+
 #createEvent will be called if an Attendance Event is create from the webpage.
 @app.route('/api/createEvent', methods=['POST'])
 def createEvent():
@@ -150,11 +175,13 @@ def createEvent():
     utils.createEventFromWeb(data)
     return make_response(jsonify({"message": "Success"}), 200)
 
+
 @app.route('/api/deleteEvent', methods=['POST'])
 def deleteEvent():
     data = request.json
     utils.deleteEvent(data.get('ID'))
     return make_response(jsonify({"message": "Success"}), 200)
+
 
 @app.route('/api/editEvent', methods=['POST'])
 def editEvent():
@@ -163,9 +190,8 @@ def editEvent():
     return make_response(jsonify({"message": "Success"}), 200)
 
 
-
 #editAccount recieves a formdata object from the front end, then updates the db data with it.
-@app.route('/api/editAccount',methods=['POST'])
+@app.route('/api/editAccount', methods=['POST'])
 def editAccount():
     accountDetails = {
         "Client": False,
@@ -207,8 +233,6 @@ def editAccount():
     return make_response(jsonify({"message": "Success"}), 200)
 
 
-
-
 #If the account being edited is an admin and there is new content, edit the admin.
 @app.route('/api/editAdmin', methods=['POST'])
 def editAdmin():
@@ -223,12 +247,29 @@ def editAdmin():
     utils.editAdministrator(newAdministrator)
     return make_response(jsonify({"message": "Success"}), 200)
 
-@app.route('/api/deleteAccount',methods=['POST'])
+
+@app.route('/api/deleteAccount', methods=['POST'])
 def deleteAccount():
     #Parse JSON Data
     data = request.json
     utils.deleteAttendee(data.get('ID'))
     return make_response(jsonify({"message": "Success"}), 200)
+
+
+# -------------- Authentication Routes ------------------------------------------
+@app.route('/api/login', methods=['POST'])
+def login():
+    #Parse JSON data
+    loginData = request.json
+    loginResponse = auth.attemptLogin(loginData.get('UserName'), loginData.get('Password'))
+    if loginResponse.get('Success') == True:
+        #Create User Token
+        userToken = create_access_token(identity=loginData.get('UserName'))
+        loginResponse['userToken'] = userToken
+        return make_response(jsonify(loginResponse)), 200
+    else:
+        return make_response(jsonify(loginResponse), 401)
+
 
 @app.route('/')
 def index():
@@ -240,7 +281,7 @@ if __name__ == '__main__':
     #---------Scheduled Processes-----------------------------------------------------------------------------
     schedule.every().day.at("21:00").do(reportScheduler.CheckReportsSchedule)
     #schedule.every(60).seconds.do(reportScheduler.CheckReportsSchedule)
-    
+
     #This may not be the most effecient way to run this code however I cannot find a more effecient way to run 
     #python code on a monthly basis. This seems to work but it does require a thread that is running that is basically
     #just polling the current date/time every 15 minutes to see if it is the correct time to generate a report

--- a/flaskServer/reports/generateReport.py
+++ b/flaskServer/reports/generateReport.py
@@ -235,11 +235,11 @@ def create_spreadsheet(params):
                 if event_date.date() == date.date():
                     if event.Absent == True:
                         worksheet.write(index + 5, colIndex + 2, "A", unapproved_cancel_format)
-                        worksheet.write_comment(index + 5, colIndex + 2, f"{event.AdminInitials}\n{event.Timestamp}",
+                        worksheet.write_comment(index + 5, colIndex + 2, f"{event.AdminInitials}\n{event.Comment}",
                                                 {'author': event.AdminInitials})
                     elif event.TIL_Violation == True:
                         worksheet.write(index + 5, colIndex + 2, "T", tardy_format)
-                        worksheet.write_comment(index + 5, colIndex + 2, f"{event.AdminInitials}\n{event.Timestamp}",
+                        worksheet.write_comment(index + 5, colIndex + 2, f"{event.AdminInitials}\n{event.Comment}",
                                                 {'author': event.AdminInitials})
                     else:
                         worksheet.write(index + 5, colIndex + 2, "P", present_format)

--- a/ptcClient/src/App.tsx
+++ b/ptcClient/src/App.tsx
@@ -8,6 +8,7 @@ import React from 'react'
 import Scanner from './pages/scanner'
 import Login from './pages/login'
 import AuthProvider from './funcitons/AuthProvider'
+import ProtectedRoute from './funcitons/ProtectedRoute'
 
 function App() {
   return (
@@ -17,8 +18,15 @@ function App() {
         <Routes>
           <Route path='' element={<Scanner/>}/>
           <Route path='login' element={<Login/>}/>
-          <Route path='events' element={<Events/>} />
-          <Route path='clients' element={<Clients/>} />
+          <Route element={<ProtectedRoute/>}>
+            <Route path='events' element={<Events/>} />
+          </Route>
+          <Route element={<ProtectedRoute/>}>
+            <Route path='clients' element={<Clients/>} />
+          </Route>
+          <Route element={<ProtectedRoute/>}>
+            <Route path='settings' element={<Scanner/>} />
+          </Route>
         </Routes>
       </Box>
     </AuthProvider>

--- a/ptcClient/src/App.tsx
+++ b/ptcClient/src/App.tsx
@@ -7,18 +7,21 @@ import { Box } from '@mui/material'
 import React from 'react'
 import Scanner from './pages/scanner'
 import Login from './pages/login'
+import AuthProvider from './funcitons/AuthProvider'
 
 function App() {
   return (
-    <Box sx={{display: 'flex'}}>
-      <Sidebar/>
-      <Routes>
-        <Route path='' element={<Scanner/>}/>
-        <Route path='login' element={<Login/>}/>
-        <Route path='events' element={<Events/>} />
-        <Route path='clients' element={<Clients/>} />
-      </Routes>
-    </Box>
+    <AuthProvider>
+      <Box sx={{display: 'flex'}}>
+        <Sidebar/>
+        <Routes>
+          <Route path='' element={<Scanner/>}/>
+          <Route path='login' element={<Login/>}/>
+          <Route path='events' element={<Events/>} />
+          <Route path='clients' element={<Clients/>} />
+        </Routes>
+      </Box>
+    </AuthProvider>
   );
 };
 

--- a/ptcClient/src/App.tsx
+++ b/ptcClient/src/App.tsx
@@ -6,6 +6,7 @@ import { Routes, Route } from 'react-router-dom'
 import { Box } from '@mui/material'
 import React from 'react'
 import Scanner from './pages/scanner'
+import Login from './pages/login'
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
       <Sidebar/>
       <Routes>
         <Route path='' element={<Scanner/>}/>
+        <Route path='login' element={<Login/>}/>
         <Route path='events' element={<Events/>} />
         <Route path='clients' element={<Clients/>} />
       </Routes>

--- a/ptcClient/src/components/editEvent.tsx
+++ b/ptcClient/src/components/editEvent.tsx
@@ -7,6 +7,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
+import { useAuth } from '../funcitons/AuthProvider';
 
 interface modalProps{
     onClose: () => void;
@@ -109,10 +110,11 @@ export default function EditEvent({onClose,EventID,Initials,Timestamp,Absent,TIL
     */
     //Hook for handling the modal loading (waiting for input)
     const [loading, setLoading] = useState(false);
-
+    //Initialize authProvider as auth for Admin Initials
+    const auth = useAuth();
     //Hook to check for event submission
     const [eventSubmitted, setEventSubmitted] = useState(false)
-    const createEvent = async () => {
+    const createEvent = async () => {        
         //Set Loading to True to disable button
         setLoading(true)
         //create the event JSON
@@ -125,7 +127,8 @@ export default function EditEvent({onClose,EventID,Initials,Timestamp,Absent,TIL
                 date: date.tz("America/Denver").format("YYYY-MM-DDTHH:mm:ss.SSS[Z]"),
                 tail: isChecked.tailCheckbox,
                 absence: isChecked.absentCheckbox,
-                comment: comment
+                comment: comment,
+                adminInitials:(isChecked.tailCheckbox || isChecked.absentCheckbox) && auth?.adminInitials ? auth?.adminInitials : 'N/A'
             })
         }
         //try catch to query backend

--- a/ptcClient/src/components/newEventModal.tsx
+++ b/ptcClient/src/components/newEventModal.tsx
@@ -7,6 +7,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
+import { useAuth } from '../funcitons/AuthProvider';
 
 interface modalProps{
     onClose: () => void;
@@ -89,13 +90,13 @@ export default function NewEvent({onClose}:modalProps){
         };
         fetchNames();
     }})
-    
+    //Initialize authProvider as auth for Admin Initials
+    const auth = useAuth();
     /**
     * Event Creation handler, this calls createEvent with appropriate information.
     */
     //Hook for handling the modal loading (waiting for input)
     const [loading, setLoading] = useState(false);
-
     //Hook to check for event submission
     const [eventSubmitted, setEventSubmitted] = useState(false)
     const createEvent = async () => {
@@ -110,7 +111,8 @@ export default function NewEvent({onClose}:modalProps){
                 date: date.tz("America/Denver").format("YYYY-MM-DDTHH:mm:ss.SSS[Z]"),
                 tail: isChecked.tailCheckbox,
                 absence: isChecked.absentCheckbox,
-                comment: comment
+                comment: comment,
+                adminInitials:(isChecked.tailCheckbox || isChecked.absentCheckbox) && auth?.adminInitials ? auth?.adminInitials : 'N/A'
             })
         }
         //try catch to query backend

--- a/ptcClient/src/components/sidebar.tsx
+++ b/ptcClient/src/components/sidebar.tsx
@@ -39,7 +39,6 @@ export default function Sidebar() {
 
   //Initialize authProvider as auth for Admin Initials
   const auth = useAuth();
-  console.log(auth)
 
   return(
       <Box>

--- a/ptcClient/src/components/sidebar.tsx
+++ b/ptcClient/src/components/sidebar.tsx
@@ -84,7 +84,7 @@ export default function Sidebar() {
               textAlign:'center'
             }}>
               {auth?.adminInitials ? 
-                    <Typography>{`Welcome, ${auth?.adminInitials}`}</Typography>: "" }
+                    <Typography sx={{mb:'.4rem'}}>{`Welcome, ${auth?.adminInitials}`}</Typography>: "" }
                 <Divider/>
                 <List>
                   <ListItemButton component={Link} to={`/settings`} sx={{ textAlign: 'center' }}>

--- a/ptcClient/src/components/sidebar.tsx
+++ b/ptcClient/src/components/sidebar.tsx
@@ -2,6 +2,7 @@ import { Box, Divider, Drawer, List, ListItem, ListItemButton, ListItemText, Typ
 import React from 'react';
 import { useState, useEffect} from 'react'
 import { Link } from 'react-router-dom'
+import { useAuth } from '../funcitons/AuthProvider';
 
 const navItems = [
   {text: 'Scanner', link: '/'},
@@ -30,9 +31,16 @@ const useWindowSize = () => {
   return windowSize;
 };
 
+
 export default function Sidebar() {
   const {width} = useWindowSize();
   const drawerWidth = width * .15;
+
+
+  //Initialize authProvider as auth for Admin Initials
+  const auth = useAuth();
+  console.log(auth)
+
   return(
       <Box>
         <Drawer
@@ -46,22 +54,53 @@ export default function Sidebar() {
             },
           }}
         >
+
           <Box sx={{ textAlign: 'center' }}>
             <Typography variant="h6" sx={{ my: 2 }}>
               PTC
             </Typography>
             <Divider />
           </Box>
-          <Box sx={{ overflow: 'auto' }}>
-          <List>
-              {navItems.map((item) => (
-                <ListItem key={item.text} disablePadding>
-                  <ListItemButton component={Link} to={item.link} sx={{ textAlign: 'center' }}>
-                    <ListItemText primary={item.text} />
-                  </ListItemButton>
-                </ListItem>
-              ))}
+          <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            height: '100%',
+          }}>
+            <Box sx={{ overflow: 'auto' }}>
+            <List>
+                {navItems.map((item) => (
+                  <ListItem key={item.text} disablePadding>
+                    <ListItemButton component={Link} to={item.link} sx={{ textAlign: 'center' }}>
+                      <ListItemText primary={item.text} />
+                    </ListItemButton>
+                  </ListItem>
+                ))}
             </List>
+            </Box>
+            <Box
+            sx={{
+              padding:2,
+              textAlign:'center'
+            }}>
+              {auth?.adminInitials ? 
+                    <Typography>{`Welcome, ${auth?.adminInitials}`}</Typography>: "" }
+                <Divider/>
+                <List>
+                  <ListItemButton component={Link} to={`/settings`} sx={{ textAlign: 'center' }}>
+                    <ListItemText primary={`Settings`}/>
+                  </ListItemButton>
+                {auth?.adminInitials ?
+                  <ListItemButton onClick={auth?.logOut} sx={{ textAlign: 'center' }}>
+                    <ListItemText primary={`Logout`}/>
+                  </ListItemButton> 
+                : <ListItemButton component={Link} to={`/login`} sx={{ textAlign: 'center' }}>
+                    <ListItemText primary={`Login`}/>
+                  </ListItemButton>
+                }
+                </List>
+            </Box>
           </Box>
         </Drawer>
       </Box>

--- a/ptcClient/src/funcitons/AuthProvider.tsx
+++ b/ptcClient/src/funcitons/AuthProvider.tsx
@@ -45,6 +45,7 @@ const AuthProvider: React.FC<authProps> = ({children}) => {
                 setAdminInitials(data.adminInitials)
                 setToken(data.userToken);
                 localStorage.setItem('token',data.userToken)
+                navigate('/events')
                 return;
             } else {
                 console.error("Error on User Login", data)

--- a/ptcClient/src/funcitons/AuthProvider.tsx
+++ b/ptcClient/src/funcitons/AuthProvider.tsx
@@ -61,7 +61,7 @@ const AuthProvider: React.FC<authProps> = ({children}) => {
     const logOut = () => {
         setAdminInitials("");
         setToken("")
-        localStorage.removeItem('site')
+        localStorage.removeItem('token')
         navigate('/login')
     };
 

--- a/ptcClient/src/funcitons/AuthProvider.tsx
+++ b/ptcClient/src/funcitons/AuthProvider.tsx
@@ -1,0 +1,52 @@
+import { useContext, createContext, useState, ReactNode } from 'react'
+import * as React from 'react'
+import { useNavigate } from 'react-router-dom'
+
+//Create element that can be read by the rest of the webapp
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+//Interface for login Credentials
+interface userCredentials {
+    username: string,
+    password: string
+}
+//Interface to wrap components within the app
+interface authProps {
+    children: ReactNode;
+}
+//Interface to define values exported from AuthProvider
+interface AuthContextType {
+    adminInitials: string | null,
+    token: string | null,
+    attemptLogin: (data: userCredentials) => Promise<void>,
+    logOut: () => void;
+}
+
+//This handles the login/logout of the webpapp
+const AuthProvider: React.FC<authProps> = ({children}) => {
+    const [adminInitials, setAdminInitials] = useState("");                 //Admin Initials -> for Assigning to comments
+    const [token, setToken] = useState(localStorage.getItem("site") || ""); //Site Token, the meat of authentication.
+    const navigate = useNavigate();
+    //This calls to the backend to attempt to login, on success it returns the adminInitials and a token for site authentication.
+    const attemptLogin = async (data: userCredentials) => {
+
+    };
+    const logOut = () => {
+        setAdminInitials("");
+        setToken("")
+        localStorage.removeItem('site')
+        navigate('/login')
+    };
+
+    return (
+        <AuthContext.Provider value={{adminInitials, token, attemptLogin, logOut}}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export default AuthProvider;
+
+export const useAuth = () => {
+    return useContext(AuthContext);
+};

--- a/ptcClient/src/funcitons/AuthProvider.tsx
+++ b/ptcClient/src/funcitons/AuthProvider.tsx
@@ -18,7 +18,7 @@ interface authProps {
 interface AuthContextType {
     adminInitials: string | null,
     token: string | null,
-    attemptLogin: (data: userCredentials) => Promise<void>,
+    attemptLogin: (data: userCredentials) => Promise<void | string>,
     logOut: () => void;
 }
 
@@ -29,7 +29,33 @@ const AuthProvider: React.FC<authProps> = ({children}) => {
     const navigate = useNavigate();
     //This calls to the backend to attempt to login, on success it returns the adminInitials and a token for site authentication.
     const attemptLogin = async (data: userCredentials) => {
-
+        const loginDetails = {
+            method: 'POST',
+            headers: {'Content-Type':'application/json',},
+            body: JSON.stringify({
+                UserName: data.username,
+                Password: data.password
+            })
+        }
+        try{
+            const login = await fetch(`/api/login`,loginDetails)
+            const data = await login.json()
+            console.log(data)
+            if(data.Success == true){
+                setAdminInitials(data.adminInitials)
+                setToken(data.userToken);
+                localStorage.setItem('token',data.userToken)
+                return;
+            } else {
+                console.error("Error on User Login", data)
+                return data.Message
+            }
+        }catch(e: any){
+            console.error("Error on User Login",e)
+            if (e.response && e.response.data && e.response.data.Success) {
+                return e.response.data.Success; // Return error message from backend
+            }
+        }
     };
     const logOut = () => {
         setAdminInitials("");

--- a/ptcClient/src/funcitons/ProtectedRoute.tsx
+++ b/ptcClient/src/funcitons/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useAuth } from './AuthProvider';
+import { Navigate, Outlet } from 'react-router-dom';
+
+const ProtectedRoute = () => {
+    //This function checks if a user is authenticated, if not it redirects someone to the login page if there someone tries to go a protected page
+    const user = useAuth();
+    if(!user?.token) return <Navigate to='/login' />;
+    return <Outlet/>
+}
+
+export default ProtectedRoute;

--- a/ptcClient/src/pages/login.tsx
+++ b/ptcClient/src/pages/login.tsx
@@ -13,6 +13,7 @@ export default function Login(){
       username: '',
       password: ''
     });
+
     //Input Change handler
     const handleChnage = (event: React.ChangeEvent<HTMLInputElement>) => {
       const {name, value} = event.target;
@@ -21,14 +22,29 @@ export default function Login(){
         [name]: value,
       }));
     };
+
+    //Loading and Error Handling
+    const [error, setError] = useState('')
+    const [success, setSuccess] = useState(false)
+    const [loading, setLoading] = useState(false)
+
     //Initialize authProvider as auth
     const auth = useAuth();
-    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+      setLoading(true)
       event.preventDefault();
       if(credentials.username !== '' && credentials.password !== ''){
-        auth?.attemptLogin(credentials)
-        return;
+        const loginError = await auth?.attemptLogin(credentials) //only returns error messages.
+        if(loginError){
+          setError(loginError);
+          setSuccess(false)
+        } else {
+          setSuccess(true)
+          setError('')
+        }
+        
       }
+      setLoading(false)
     }
 
 
@@ -82,10 +98,13 @@ export default function Login(){
             variant="contained"
             color="primary"
             fullWidth
-            sx={{ marginTop: '1rem' }}
+            sx={{ marginTop: '1rem',mb:'.4rem' }}
+            disabled={loading}
           >
-            Login
+            {loading ? 'Loading' : 'Login'}
           </Button>
+          {success ? <Typography variant="h6" color='green'>Login Successful</Typography> : ''}
+          {error ? <Typography variant="h6" color='red'>{error}</Typography> : ''}
         </form>
       </Box>
     </Box>

--- a/ptcClient/src/pages/login.tsx
+++ b/ptcClient/src/pages/login.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import {useState} from 'react';
+import {Box,Typography,TextField,Button} from '@mui/material'
+import { useAuth } from "../funcitons/AuthProvider";
+
+
+//https://dev.to/miracool/how-to-manage-user-authentication-with-react-js-3ic5 Template to build this off of
+
+
+export default function Login(){
+    //Hook for Credentials Object to be passed to AuthProvider
+    const [credentials, setCredentials] = useState({
+      username: '',
+      password: ''
+    });
+    //Input Change handler
+    const handleChnage = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const {name, value} = event.target;
+      setCredentials((prev) => ({
+        ...prev,
+        [name]: value,
+      }));
+    };
+    //Initialize authProvider as auth
+    const auth = useAuth();
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if(credentials.username !== '' && credentials.password !== ''){
+        auth?.attemptLogin(credentials)
+        return;
+      }
+    }
+
+
+    return(
+    <Box
+      sx={{
+        width: '100vw',
+        height: '100vh',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#f0f0f0',
+      }}
+    >
+      <Box
+        sx={{
+          padding: '2rem',
+          backgroundColor: 'white',
+          borderRadius: '8px',
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+          minWidth: '300px',
+        }}
+      >
+        <Typography variant="h5" component="h1" gutterBottom color='black'>
+          Login
+        </Typography>
+        <form onSubmit={handleSubmit}>
+          <TextField
+            label="Username"
+            name="username"
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            value={credentials.username}
+            onChange={handleChnage}
+            required
+          />
+          <TextField
+            label="Password"
+            name="password"
+            type="password"
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            value={credentials.password}
+            onChange={handleChnage}
+            required
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            sx={{ marginTop: '1rem' }}
+          >
+            Login
+          </Button>
+        </form>
+      </Box>
+    </Box>
+    )
+}

--- a/ptcClient/src/pages/login.tsx
+++ b/ptcClient/src/pages/login.tsx
@@ -30,6 +30,7 @@ export default function Login(){
 
     //Initialize authProvider as auth
     const auth = useAuth();
+    //Submit Handler.
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
       setLoading(true)
       event.preventDefault();


### PR DESCRIPTION
Added Login Page
![image](https://github.com/user-attachments/assets/a5064ea8-7868-43e8-9980-13f731477623)

Sidebar was also updated to reflect changes
![image](https://github.com/user-attachments/assets/fa9af03f-762d-405e-b5e9-98aaed467779)

Selecting anything other than scanner at the moment redirects to login page while not logged in.

Logging into the webapp will make these pages accessible, and updates the sidebar like this
![image](https://github.com/user-attachments/assets/e121dd44-e804-46b3-9145-a6559ed290c2)

At the moment only the webpages are password protected, there are still internal routes that may need to be protected, but I need to experiment/determine if its worth the time.

To go with the request of PTC and professor Mettler, there is a hard coded login that doesn't require an account.
username: admin
password: admin

This must be changed in auth.py before we fully ship this, with a specific username and some kind of encrypted password.