### PR TITLE
Adding Event Types to Generate Report + Fixing End Date 

### DIFF
--- a/flaskServer/app.py
+++ b/flaskServer/app.py
@@ -39,7 +39,8 @@ def generate_report():
     role = data.get('role')
     start_date = data.get('startDate')
     end_date = data.get('endDate')
-    fileName = generateReport.generate_spreadsheet(name, role, start_date, end_date)
+    eventType = data.get('eventType')
+    fileName = generateReport.generate_spreadsheet(name, role,eventType, start_date, end_date)
     #Checking if file exists for a minute before throwing an error.
     start_time = time.time()
     while time.time() - start_time < 60:

--- a/ptcClient/src/App.tsx
+++ b/ptcClient/src/App.tsx
@@ -6,6 +6,7 @@ import { Routes, Route } from 'react-router-dom'
 import { Box } from '@mui/material'
 import React from 'react'
 import Scanner from './pages/scanner'
+import Table from './components/table'
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
         <Route path='' element={<Scanner/>}/>
         <Route path='events' element={<Events/>} />
         <Route path='clients' element={<Clients/>} />
+        <Route path='table' element={<Table/>}/>
       </Routes>
     </Box>
   );

--- a/ptcClient/src/components/reportModal.tsx
+++ b/ptcClient/src/components/reportModal.tsx
@@ -4,6 +4,12 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Fragment, useEffect, useState } from "react";
 import * as React from "react"; 
 import axios from 'axios'
+import dayjs from "dayjs";
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 function ReportModal(){
     //Open React Hook
@@ -13,6 +19,10 @@ function ReportModal(){
       setOpen(true);
     };
     const handleClose = () => {
+      handleAutoCompleteChange('roleAutoComplete', '')
+      handleAutoCompleteChange('nameAutoComplete', '')
+      setStartDate(dayjs())
+      setEndDate(dayjs())
       setOpen(false);
     };
 
@@ -51,8 +61,8 @@ function ReportModal(){
     }})
 
     //Date Hooks
-    const [startDate, setStartDate]=useState(null);
-    const [endDate, setEndDate]=useState(null);
+    const [startDate, setStartDate]=useState(dayjs());
+    const [endDate, setEndDate]=useState(dayjs());
     
     //Checkbox hook, identifies which checkbox then changes it
     const [isChecked, setIsChecked] = useState<{ [key: string]: boolean }>({
@@ -88,8 +98,8 @@ function ReportModal(){
           body: JSON.stringify({
             "name": autoCompleteVal.nameAutoComplete,
             "role": autoCompleteVal.roleAutoComplete,
-            "startDate": startDate,
-            "endDate": endDate
+            "startDate": startDate.tz("America/Denver").format("YYYY-MM-DDTHH:mm:ss.SSS[Z]"),
+            "endDate": endDate.tz("America/Denver").format("YYYY-MM-DDTHH:mm:ss.SSS[Z]")
           })}
       //Try 
       console.log(report)
@@ -109,9 +119,6 @@ function ReportModal(){
             })
           }
         );
-        if(!response.ok){
-          throw new Error(`Error: ${response.statusText}`);
-        }  
       } catch(e: any){
         console.log(e.message);
       }
@@ -157,7 +164,7 @@ function ReportModal(){
                 label="Start Date" 
                 sx={{mb:'.5rem',mx:'.8rem'}}
                 value={startDate}
-                onChange={(newDate: any)=> setStartDate(newDate)}
+                onChange={(newDate: any)=> setStartDate(dayjs(newDate).startOf('day'))}
                 maxDate={endDate}
                 />
             </LocalizationProvider>
@@ -166,7 +173,7 @@ function ReportModal(){
                 label="End Date" 
                 sx={{mb:'.5rem',mx:'.8rem'}} 
                 value={endDate}
-                onChange={(newDate: any)=> setEndDate(newDate)}
+                onChange={(newDate: any)=> setEndDate(dayjs(newDate).endOf('day'))}
                 minDate={startDate}
                 />
             </LocalizationProvider>

--- a/ptcClient/src/components/reportModal.tsx
+++ b/ptcClient/src/components/reportModal.tsx
@@ -19,13 +19,13 @@ function ReportModal(){
       setOpen(true);
     };
     const handleClose = () => {
-      handleAutoCompleteChange('roleAutoComplete', '')
-      handleAutoCompleteChange('nameAutoComplete', '')
+      handleAutoCompleteChange('roleAutoComplete', [])
+      handleAutoCompleteChange('nameAutoComplete', [])
       setStartDate(dayjs())
       setEndDate(dayjs())
       setOpen(false);
     };
-
+    //Get the Roles in the database, and present them in autocomplete boxes
     const [roles, setRoles] = useState([]);
     const [hasFetchedRoles, setHasFetchedRoles] = useState(false)
     useEffect(()=> {
@@ -42,7 +42,7 @@ function ReportModal(){
         };
         fetchRoles();
     }})
-
+    //Get names (attendee initials) in the database, and present them for choice.
     const [names, setNames] = useState([]);
     const [hasFetchedNames, setHasFetchedNames] = useState(false)
     useEffect(()=> {
@@ -60,6 +60,9 @@ function ReportModal(){
         fetchNames();
     }})
 
+    //Setup the couple attendance event types.
+    const eventTypes = [ 'Present', 'Absent','TIL'];
+
     //Date Hooks
     const [startDate, setStartDate]=useState(dayjs());
     const [endDate, setEndDate]=useState(dayjs());
@@ -68,6 +71,7 @@ function ReportModal(){
     const [isChecked, setIsChecked] = useState<{ [key: string]: boolean }>({
       nameCheckbox: false,
       roleCheckbox: false,
+      eventTypeCheckBox: false,
     });
     //Checkbox Handler
     const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -80,8 +84,9 @@ function ReportModal(){
 
     //Autocomplete Hook, works the same as the Checkbox, but with different value content.
     const [autoCompleteVal, setAutoCompleteVal] =  useState<{[key: string]: any}>({
-      nameAutoComplete: null,
-      roleAutoComplete: null
+      nameAutoComplete: [],
+      roleAutoComplete: [],
+      eventTypeAutoComplete: [],
     });
     const handleAutoCompleteChange = (name: string, newValue: any) => {
       setAutoCompleteVal((prevState) => ({
@@ -98,6 +103,7 @@ function ReportModal(){
           body: JSON.stringify({
             "name": autoCompleteVal.nameAutoComplete,
             "role": autoCompleteVal.roleAutoComplete,
+            "eventType": autoCompleteVal.eventTypeAutoComplete,
             "startDate": startDate.tz("America/Denver").format("YYYY-MM-DDTHH:mm:ss.SSS[Z]"),
             "endDate": endDate.tz("America/Denver").format("YYYY-MM-DDTHH:mm:ss.SSS[Z]")
           })}
@@ -137,6 +143,7 @@ function ReportModal(){
               checked={isChecked.nameCheckbox}
               onChange={handleCheckboxChange}/>
             <Autocomplete 
+              multiple
               key="nameAutoComplete"
               sx={{ width: 300 }}
               options={names} 
@@ -151,6 +158,7 @@ function ReportModal(){
               checked={isChecked.roleCheckbox}
               onChange={handleCheckboxChange}/>
             <Autocomplete
+              multiple
               key="roleAutoComplete" 
               sx={{ width: 300 }}
               options={roles} 
@@ -158,6 +166,21 @@ function ReportModal(){
               onChange={(_name: any, newValue: any) => handleAutoCompleteChange('roleAutoComplete', newValue)}
               value={autoCompleteVal.roleAutoComplete}
               renderInput={(params) => <TextField {...params} label="Role" />}/>
+          </Box>
+          <Box display="flex" sx={{mb:'.6rem',mx:'.8rem'}}>
+            <Checkbox 
+              name="eventTypeCheckBox"
+              checked={isChecked.eventTypeCheckBox}
+              onChange={handleCheckboxChange}/>
+            <Autocomplete
+              multiple
+              key="roleAutoComplete" 
+              sx={{ width: 300 }}
+              options={eventTypes} 
+              disabled={!isChecked.eventTypeCheckBox} 
+              onChange={(_name: any, newValue: any) => handleAutoCompleteChange('eventTypeAutoComplete', newValue)}
+              value={autoCompleteVal.eventTypeAutoComplete}
+              renderInput={(params) => <TextField {...params} label="Event Type" />}/>
           </Box>
             <LocalizationProvider dateAdapter={AdapterDayjs}>
               <DatePicker 

--- a/ptcClient/src/components/table.tsx
+++ b/ptcClient/src/components/table.tsx
@@ -2,9 +2,78 @@ import { AgGridReact } from 'ag-grid-react'; // React Data Grid Component
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-quartz.css";
 import * as React from "react"; 
-
+import { Box, TextField } from '@mui/material';
+import { useCallback, useRef, useState } from 'react';
+import { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
+// Row Data Interface
+interface IRow {
+    make: string;
+    model: string;
+    price: number;
+    electric: boolean;
+}
 function Table(){
+// Row Data: The data to be displayed.
+const [rowData, setRowData] = useState<IRow[]>([
+    { make: "Tesla", model: "Model Y", price: 64950, electric: true },
+    { make: "Ford", model: "F-Series", price: 33850, electric: false },
+    { make: "Toyota", model: "Corolla", price: 29600, electric: false },
+    { make: "Mercedes", model: "EQA", price: 48890, electric: true },
+    { make: "Fiat", model: "500", price: 15774, electric: false },
+    { make: "Nissan", model: "Juke", price: 20675, electric: false },
+  ]);
 
+  // Column Definitions: Defines & controls grid columns.
+  const [colDefs, setColDefs] = useState<ColDef[]>([
+    { field: "make" },
+    { field: "model" },
+    { field: "price" },
+    { field: "electric" },
+  ]);
+
+  //expose grid and column api for custom functionality
+  const gridApiRef = useRef<GridApi | null>(null);
+
+  const onGridReady = (params: GridReadyEvent) => {
+    gridApiRef.current = params.api;
+  };
+
+     //Create a quick exterior filter for looking up table data
+    // Function to apply quick filter using the exposed gridApi
+    const onFilterTextBoxChanged = useCallback(() => {
+        gridApiRef.current!.setGridOption(
+          "quickFilterText",
+          (document.getElementById("filter-text-box") as HTMLInputElement).value,
+        );
+      }, []);;
+
+    return (
+        <>
+        <Box
+              sx={{
+                display: 'block',
+                flexGrow: 1,
+                bgcolor: 'background.paper',
+              }}>
+                <TextField
+                type='text'
+                id="filter-text-box"
+                placeholder='Filter'
+                onInput={onFilterTextBoxChanged}
+                />
+              <div
+                className="ag-theme-quartz"
+                style={{ height: 750, width: '125vh' }} // the Data Grid will fill the size of the parent container
+              >
+                <AgGridReact
+                    rowData={rowData}
+                    columnDefs={colDefs}
+                    onGridReady={onGridReady}
+              />
+              </div>
+        </Box>
+        </>
+    )
 }
 
 export default Table

--- a/ptcClient/vite.config.ts
+++ b/ptcClient/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: 'http://192.168.26.7:5000',
         changeOrigin: true,
         secure: false,
       },

--- a/ptcClient/vite.config.ts
+++ b/ptcClient/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://192.168.26.7:5000',
+        target: 'http://localhost:5000',
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
This pull requests adds as missing component from our spec 2.1.1 requirement
Event Types are now added.
![image](https://github.com/user-attachments/assets/9d52dcec-3cc5-47b0-97db-bbb958fd4e5d)

Additionally, endDate now correctly assigns the whole day, not truncated events at 12:00am
![image](https://github.com/user-attachments/assets/22674e99-aff4-46b7-98cd-2d08c5cea13c)

This PR also begins adding the table wrapper, which shouldn't have carried over, but it is inaccessible from the webpage otherwise. 