### PR TITLE
Automatic monthly and weekly report mailing server

### DIFF
--- a/flaskServer/reports/.gitignore
+++ b/flaskServer/reports/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
 __pycache__/*
 xlsx/*
+mailerCredentials.py
 

--- a/flaskServer/reports/mailer.py
+++ b/flaskServer/reports/mailer.py
@@ -1,0 +1,18 @@
+from flask import Flask
+from flask_mail import Mail, Message
+
+def SendWeeklyReport(app, mail, fileName):
+    print("Sending weekly report!")
+    msg = Message(subject='Weekly attendance report', sender='55atatattendance@gmail.com', recipients=['drewcurt6@gmail.com'])
+    msg.body = "Weekly report of attendance at PTC"
+    with app.open_resource("xlsx/"+fileName, "rb") as ReportFile:
+        msg.attach("xlsx/"+fileName, "report/xlsx", ReportFile.read())
+    mail.send(msg)
+
+
+def SendMonthlyReport(app, mail, fileName):
+    msg = Message(subject='Monthly attendance report', sender='55atatattendance@gmail.com', recipients=['drewcurt6@gmail.com'])
+    msg.body = "Monthly report of attendance at PTC. It is recommended to save this report for archival use. Attendance events older than 2 months are deleted."
+    with app.open_resource("xlsx/"+fileName, "rb") as ReportFile:
+        msg.attach("xlsx/"+fileName, "report/xlsx", ReportFile.read())
+    mail.send(msg)

--- a/flaskServer/reports/reportScheduler.py
+++ b/flaskServer/reports/reportScheduler.py
@@ -7,6 +7,8 @@
  # the ArchiveAttendanceEvents database table, and then when verified the data has been transferred, it will empty the currentAttendanceEvents 
  # database table to prepare for the next month of attendance events.
 
+#10/17/2024 Update:
+#Adding mailing feature to automatically send reports via an email client
 
 #Libraries used:
 from datetime import datetime, timedelta, date
@@ -17,16 +19,18 @@ from reports import generateReport
 sys.path.insert(0, '/home/drew/Documents/capstone/55ATAT/APIFuncs')
 import utils
 
+#Import mailing service
+from reports import mailer
 
 
-def CheckReportsSchedule():
+def CheckReportsSchedule(app, mail):
     print("Checking if reports need generated today")
     today = datetime.today()
     #Check if today is friday
     #Maps the days of the week on Monday = 0 through Sunday = 6
     if date.today().weekday() == 4:
          #If it is Friday create the weekly report
-         weekly_reports()
+         weekly_reports(app, mail)
     time.sleep(60)
     
     #Check if today is the last day of the month -> Must happen after week as month clears database
@@ -34,7 +38,7 @@ def CheckReportsSchedule():
     #If today is equal to the last day of the month create a report
     if calendar.monthrange(today.year, today.month)[1] == today.day:
          #If it is the last day of the month, generate monthly attendance report
-         monthly_reports()
+         monthly_reports(app, mail)
          #Delete archival records then move current records into archive
          #Archive records and then delete records from current attedance event table
          #This resets the database in prepartion for the new month
@@ -47,19 +51,22 @@ def CheckReportsSchedule():
 
 
 
-def weekly_reports():
+def weekly_reports(app, mail):
     print("Weekly report generation called.")
     fileName = generateReport.generate_spreadsheet(start_date=(datetime.now() - timedelta(weeks= 1)).strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
     print(fileName)
-    #TODO: Link with flaskMail to send an email with the attachment. 
+    mailer.SendWeeklyReport(app, mail, fileName)
+    #TODO: Link with flaskMail to send an email with the attachment.
 
 
 
-def monthly_reports():
+
+def monthly_reports(app, mail):
     print("Montly report generation called.")
     fileName = generateReport.generate_spreadsheet(start_date=(datetime.now() - timedelta(weeks= 4)).strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+    mailer.SendMonthlyReport(app, mail, fileName)
     print(fileName)
     
 if __name__ == '__main__':
-        sys.exit(CheckReportsSchedule())
+        sys.exit(print("Do not run this file directly!"))
  

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pillow~=10.4.0
 qrcode~=6.1
 PyJWT==2.9.0
 flask-jwt-extended==4.6.0
+Flask-Mail==0.10.0


### PR DESCRIPTION
## Weekly and Monthly reports are now mailed out!
> [!CAUTION]
> I have created a local file on the Pi to track the login credentials for the temp email. I do not want this in the repo and it must be manually moved over to dev after the merge is complete or the system will not send emails.

I created two functions to mail reports, one for weekly reports and one for monthly reports. These are fairly basic functions that expect to only be called when creating the automatic reports. 

Example emails:
![AttendanceEmails](https://github.com/user-attachments/assets/08ea5a0c-94f9-40d5-91c2-6292c3295529)

Weekly Preview:
![PreviewWeeklyReport](https://github.com/user-attachments/assets/e41da164-0761-4340-958e-42851b050078)

Monthly Email:
![MonthlyAttendanceReportEmail](https://github.com/user-attachments/assets/84979652-ea84-42e1-900d-2fbd7a052321)

Once downloaded the formatting is preserved.
![DownloadedMonthlyReport](https://github.com/user-attachments/assets/758c2473-38fc-485e-892e-fe4c81dda731)
![EmailedWeeklyReportDownloaded](https://github.com/user-attachments/assets/bebee156-9f6e-4a42-bc28-d29206471423)


 I see no issues, and this has been tested on the Pi so all routing and pathing is correct in this branch. 

### Potentially missing features:
The file name is not great. This could be vastly improved but the file name comes directly from the filename provided from the generate reports feature. 

This resolves: #15 and moved us closer to the SPD milestone. 