### PR TITLE
Clearing Values in Modals

### DIFF
--- a/ptcClient/src/components/clientModal.tsx
+++ b/ptcClient/src/components/clientModal.tsx
@@ -24,6 +24,7 @@ function ClientModal({onClose}: modalProps){
       setUsername('')
       setPwd('')
       setBadgeURLs(null)
+      handleAutoCompleteChange('roleAutoComplete', [])
       //Close modal
       setOpen(false);
       setDisplayBadge(false)

--- a/ptcClient/src/components/reportModal.tsx
+++ b/ptcClient/src/components/reportModal.tsx
@@ -21,6 +21,11 @@ function ReportModal(){
     const handleClose = () => {
       handleAutoCompleteChange('roleAutoComplete', [])
       handleAutoCompleteChange('nameAutoComplete', [])
+      setIsChecked({
+        nameCheckbox: false,
+        roleCheckbox: false,
+        eventTypeCheckBox: false,
+      });
       setStartDate(dayjs())
       setEndDate(dayjs())
       setOpen(false);

--- a/ptcClient/src/components/reportModal.tsx
+++ b/ptcClient/src/components/reportModal.tsx
@@ -21,6 +21,7 @@ function ReportModal(){
     const handleClose = () => {
       handleAutoCompleteChange('roleAutoComplete', [])
       handleAutoCompleteChange('nameAutoComplete', [])
+      handleAutoCompleteChange('eventTypeAutoComplete', [])
       setIsChecked({
         nameCheckbox: false,
         roleCheckbox: false,


### PR DESCRIPTION
This fixes spots where modals would not unload data when closed.

Report Generation Modal:
Previously checkboxes would not clear, and event type would persist between closing.

![image](https://github.com/user-attachments/assets/db19b6a8-b4c6-4adf-8630-7a122c6f1fbb)

Attendee Modal:
Previously roles would not clear.

![image](https://github.com/user-attachments/assets/a0bf528a-2c12-4767-9f3c-71fccee48205)

Closes #35 
